### PR TITLE
test: Refactor XMLSign tests to match updated module API

### DIFF
--- a/Tests/XMLSign.Tests.ps1
+++ b/Tests/XMLSign.Tests.ps1
@@ -23,67 +23,113 @@ Describe "XMLSign Module Tests" {
     }
 
     Context "Module Import" {
-        It "Should import the module successfully" -Skip:(-not $AzModulesAvailable) {
+        It "Should import the module successfully" {
             Get-Module XMLSign | Should -Not -BeNullOrEmpty
         }
 
-        It "Should export the Sign-XMLDocument function" -Skip:(-not $AzModulesAvailable) {
+        It "Should export the Invoke-XMLSign function" {
             $commands = Get-Command -Module XMLSign
-            $commands.Name | Should -Contain "Sign-XMLDocument"
+            $commands.Name | Should -Contain "Invoke-XMLSign"
         }
 
-        It "Should not export Connect-XMLSignKeyVault function" -Skip:(-not $AzModulesAvailable) {
+        It "Should export the Test-XMLSignature function" {
             $commands = Get-Command -Module XMLSign
-            $commands.Name | Should -Not -Contain "Connect-XMLSignKeyVault"
+            $commands.Name | Should -Contain "Test-XMLSignature"
         }
 
-        It "Should have exactly two exported functions" -Skip:(-not $AzModulesAvailable) {
+        It "Should have exactly two exported functions" {
             $commands = Get-Command -Module XMLSign
             $commands.Count | Should -Be 2
         }
+
+        It "Should not export private functions" {
+            $commands = Get-Command -Module XMLSign
+            $commands.Name | Should -Not -Contain "Get-KeyVaultCertificateAndKey"
+            $commands.Name | Should -Not -Contain "Invoke-AzureKeyVaultSign"
+            $commands.Name | Should -Not -Contain "New-XMLSignature"
+        }
     }
 
-    Context "Sign-XMLDocument Function" {
+    Context "Invoke-XMLSign Function" {
         BeforeAll {
             if ($AzModulesAvailable) {
-                $function = Get-Command Sign-XMLDocument
+                $function = Get-Command Invoke-XMLSign
             }
         }
 
-        It "Should have the correct parameters" -Skip:(-not $AzModulesAvailable) {
+        It "Should have the correct parameters" {
             $parameters = $function.Parameters.Keys
-            $parameters | Should -Contain "XmlPath"
+            $parameters | Should -Contain "KeyVaultName"
             $parameters | Should -Contain "CertificateName"
-            $parameters | Should -Contain "VaultName"
-            $parameters | Should -Contain "OutputPath"
-            $parameters | Should -Contain "ReferenceUri"
+            $parameters | Should -Contain "XmlFileToSign"
+            $parameters | Should -Contain "XmlFileToSave"
+            $parameters | Should -Contain "TenantId"
         }
 
-        It "Should have mandatory parameters" -Skip:(-not $AzModulesAvailable) {
-            $function.Parameters.XmlPath.Attributes.Mandatory | Should -Be $true
+        It "Should have mandatory parameters" {
+            $function.Parameters.KeyVaultName.Attributes.Mandatory | Should -Be $true
             $function.Parameters.CertificateName.Attributes.Mandatory | Should -Be $true
-            $function.Parameters.VaultName.Attributes.Mandatory | Should -Be $true
+            $function.Parameters.XmlFileToSign.Attributes.Mandatory | Should -Be $true
+            $function.Parameters.XmlFileToSave.Attributes.Mandatory | Should -Be $true
         }
 
-        It "Should have optional parameters" -Skip:(-not $AzModulesAvailable) {
-            $function.Parameters.OutputPath.Attributes.Mandatory | Should -Be $false
-            $function.Parameters.ReferenceUri.Attributes.Mandatory | Should -Be $false
+        It "Should have optional parameters" {
+            $function.Parameters.TenantId.Attributes.Mandatory | Should -Be $false
         }
 
-        It "Should have help documentation" -Skip:(-not $AzModulesAvailable) {
-            $help = Get-Help Sign-XMLDocument
+        It "Should have help documentation" {
+            $help = Get-Help Invoke-XMLSign
             $help.Synopsis | Should -Not -BeNullOrEmpty
             $help.Description | Should -Not -BeNullOrEmpty
         }
 
-        It "Should have parameter help" -Skip:(-not $AzModulesAvailable) {
-            $help = Get-Help Sign-XMLDocument -Parameter XmlPath
+        It "Should have parameter help" {
+            $help = Get-Help Invoke-XMLSign -Parameter XmlFileToSign
             $help.Description | Should -Not -BeNullOrEmpty
         }
 
-        It "Should have examples in help" -Skip:(-not $AzModulesAvailable) {
-            $help = Get-Help Sign-XMLDocument
+        It "Should have examples in help" {
+            $help = Get-Help Invoke-XMLSign
             $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Context "Test-XMLSignature Function" {
+        BeforeAll {
+            if ($AzModulesAvailable) {
+                $function = Get-Command Test-XMLSignature
+            }
+        }
+
+        It "Should have the correct parameters" {
+            $parameters = $function.Parameters.Keys
+            $parameters | Should -Contain "XmlFilePath"
+        }
+
+        It "Should have mandatory parameters" {
+            $function.Parameters.XmlFilePath.Attributes.Mandatory | Should -Be $true
+        }
+
+        It "Should have help documentation" {
+            $help = Get-Help Test-XMLSignature
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            $help.Description | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have parameter help" {
+            $help = Get-Help Test-XMLSignature -Parameter XmlFilePath
+            $help.Description | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have examples in help" {
+            $help = Get-Help Test-XMLSignature
+            $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+
+        It "Should return boolean value" {
+            # Test with a non-existent file to ensure it returns false
+            $result = Test-XMLSignature -XmlFilePath "NonExistentFile.xml" -ErrorAction SilentlyContinue
+            $result | Should -BeOfType [bool]
         }
     }
 
@@ -103,14 +149,15 @@ Describe "XMLSign Module Tests" {
             $manifestContent = Get-Content $ModulePath -Raw
             $manifestContent | Should -Match "ModuleVersion\s*=\s*'1\.0\.0'"
             $manifestContent | Should -Match "RequiredModules\s*=.*Az\.Accounts.*Az\.KeyVault"
-            $manifestContent | Should -Match "'Sign-XMLDocument'"
-            $manifestContent | Should -Not -Match "Connect-XMLSignKeyVault"
+            $manifestContent | Should -Match "'Invoke-XMLSign'"
+            $manifestContent | Should -Match "'Test-XMLSignature'"
         }
     }
 
-    Context "Sample XML File" {
+    Context "Sample XML File and Signed XML Validation" {
         BeforeAll {
             $SampleXmlPath = Join-Path $PSScriptRoot ".." "sample.xml"
+            $SignedXmlPath = Join-Path $PSScriptRoot ".." "signed.xml"
         }
 
         It "Should have a sample XML file" {
@@ -123,34 +170,63 @@ Describe "XMLSign Module Tests" {
                 { $xml.Load($SampleXmlPath) } | Should -Not -Throw
             }
         }
+
+        It "Should validate signed XML if signed.xml exists" {
+            if (Test-Path $SignedXmlPath) {
+                $result = Test-XMLSignature -XmlFilePath $SignedXmlPath
+                $result | Should -BeOfType [bool]
+                # If signed.xml exists and is properly signed, it should return true
+                # If it's just a placeholder or invalid, it might return false
+                Write-Host "Signed XML validation result: $result" -ForegroundColor Cyan
+            } else {
+                Set-ItResult -Skipped -Because "signed.xml file not found"
+            }
+        }
+
+        It "Should detect unsigned XML file" {
+            if (Test-Path $SampleXmlPath) {
+                $result = Test-XMLSignature -XmlFilePath $SampleXmlPath
+                $result | Should -Be $false
+            }
+        }
     }
 
     Context "Private Functions" {
-        It "Should have Get-KeyVaultCertificate private function" {
-            $privatePath = Join-Path $PSScriptRoot ".." "XMLSign" "Private" "Get-KeyVaultCertificate.ps1"
+        It "Should have Get-KeyVaultCertificateAndKey private function" {
+            $privatePath = Join-Path $PSScriptRoot ".." "XMLSign" "Private" "Get-KeyVaultCertificateAndKey.ps1"
             Test-Path $privatePath | Should -Be $true
         }
 
-        It "Should have Invoke-XMLSigning private function" {
-            $privatePath = Join-Path $PSScriptRoot ".." "XMLSign" "Private" "Invoke-XMLSigning.ps1"
+        It "Should have Invoke-AzureKeyVaultSign private function" {
+            $privatePath = Join-Path $PSScriptRoot ".." "XMLSign" "Private" "Invoke-AzureKeyVaultSign.ps1"
             Test-Path $privatePath | Should -Be $true
         }
 
-        It "Should not have Connect-XMLSignKeyVault function" {
-            $publicPath = Join-Path $PSScriptRoot ".." "XMLSign" "Public" "Connect-XMLSignKeyVault.ps1"
-            Test-Path $publicPath | Should -Be $false
+        It "Should have New-XMLSignature private function" {
+            $privatePath = Join-Path $PSScriptRoot ".." "XMLSign" "Private" "New-XMLSignature.ps1"
+            Test-Path $privatePath | Should -Be $true
         }
     }
 
-    Context "Error Handling" -Skip:(-not $AzModulesAvailable) {
-        It "Should throw error for non-existent XML file" {
-            { Sign-XMLDocument -XmlPath "C:\NonExistent\file.xml" -CertificateName "TestCert" -VaultName "TestVault" } | Should -Throw
+    Context "Error Handling" {
+        It "Should handle non-existent XML file in Invoke-XMLSign" {
+            { Invoke-XMLSign -KeyVaultName "TestVault" -CertificateName "TestCert" -XmlFileToSign "C:\NonExistent\file.xml" -XmlFileToSave "output.xml" } | Should -Throw
         }
 
-        It "Should validate parameters correctly" {
-            { Sign-XMLDocument -XmlPath "" -CertificateName "TestCert" -VaultName "TestVault" } | Should -Throw
-            { Sign-XMLDocument -XmlPath "test.xml" -CertificateName "" -VaultName "TestVault" } | Should -Throw
-            { Sign-XMLDocument -XmlPath "test.xml" -CertificateName "TestCert" -VaultName "" } | Should -Throw
+        It "Should handle non-existent XML file in Test-XMLSignature" {
+            $result = Test-XMLSignature -XmlFilePath "C:\NonExistent\file.xml" -ErrorAction SilentlyContinue
+            $result | Should -Be $false
+        }
+
+        It "Should validate required parameters for Invoke-XMLSign" {
+            { Invoke-XMLSign -KeyVaultName "" -CertificateName "TestCert" -XmlFileToSign "test.xml" -XmlFileToSave "output.xml" } | Should -Throw
+            { Invoke-XMLSign -KeyVaultName "TestVault" -CertificateName "" -XmlFileToSign "test.xml" -XmlFileToSave "output.xml" } | Should -Throw
+            { Invoke-XMLSign -KeyVaultName "TestVault" -CertificateName "TestCert" -XmlFileToSign "" -XmlFileToSave "output.xml" } | Should -Throw
+            { Invoke-XMLSign -KeyVaultName "TestVault" -CertificateName "TestCert" -XmlFileToSign "test.xml" -XmlFileToSave "" } | Should -Throw
+        }
+
+        It "Should validate required parameters for Test-XMLSignature" {
+            { Test-XMLSignature -XmlFilePath "" } | Should -Throw
         }
     }
 }


### PR DESCRIPTION
Fix for #6 
- Update function tests from Sign-XMLDocument to Invoke-XMLSign
- Add comprehensive Test-XMLSignature function test coverage
- Update parameter names to match new function signatures:
  * XmlPath → XmlFileToSign
  * VaultName → KeyVaultName
  * OutputPath → XmlFileToSave
  * Add TenantId parameter validation
- Add private function file existence tests for:
  * Get-KeyVaultCertificateAndKey.ps1
  * Invoke-AzureKeyVaultSign.ps1
  * New-XMLSignature.ps1
- Enhance signed XML validation with signed.xml file testing
- Improve error handling tests with parameter validation
- Add help documentation validation for both public functions
- Remove conditional test skipping for better test reliability
- Update module manifest validation to check correct exported functions

The test suite now provides comprehensive coverage for the refactored XMLSign module with improved parameter